### PR TITLE
Implement API for process init / jump

### DIFF
--- a/schemas.ts
+++ b/schemas.ts
@@ -10,9 +10,10 @@ const settings: PartialArgs = {
 const program = getProgramFromFiles([resolve('./src/types.d.ts')]);
 
 const types = [
+  'AutomationProcess',
+  'AutomationStepJump',
   'AutomationTask',
   'AutomationTemplate',
-  'AutomationProcess',
   'EventbusMessage',
 ];
 

--- a/src/handlers/time-elapsed.ts
+++ b/src/handlers/time-elapsed.ts
@@ -8,7 +8,7 @@ import { ConditionHandler } from './types';
  * If current step is used, the start time is the moment action application was done.
  */
 const handler: ConditionHandler<TimeElapsedImpl> = {
-  async check({ impl }, { proc, activeStep }) {
+  async check({ impl }, { proc, activeStep, activeResult }) {
     if (impl.duration <= 0) {
       return true;
     }
@@ -20,9 +20,9 @@ const handler: ConditionHandler<TimeElapsedImpl> = {
       for (let i = proc.results.length - 1; i >= 0; --i) {
         const result = proc.results[i];
         if (result.stepId === activeStep.id && result.stepStatus === 'Created') {
-          // We start counting from the moment actions were applied
+          // We start counting from the moment the step entered the current status
           const startResult = proc.results.slice(i)
-            .find(v => v.stepId === activeStep.id && v.stepStatus === 'Active');
+            .find(v => v.stepId === activeStep.id && v.stepStatus === activeResult.stepStatus);
           return startResult !== undefined
             ? startResult.date + impl.duration < new Date().getTime()
             : false;

--- a/src/schemas/AutomationProcess.json
+++ b/src/schemas/AutomationProcess.json
@@ -59,12 +59,16 @@
           ]
         },
         "stepStatus": {
-          "$ref": "#/definitions/AutomationStatus",
+          "$ref": "#/definitions/AutomationStepStatus",
           "description": "Current status for the relevant step.\nWill be Invalid if stepId is null."
         },
         "processStatus": {
           "$ref": "#/definitions/AutomationStatus",
           "description": "Current status for the entire process.\nThe process will only be evaluated if it is Active."
+        },
+        "error": {
+          "description": "Relevant error message.",
+          "type": "string"
         }
       },
       "required": [
@@ -74,6 +78,18 @@
         "stepId",
         "stepStatus"
       ]
+    },
+    "AutomationStepStatus": {
+      "enum": [
+        "Actions",
+        "Cancelled",
+        "Created",
+        "Finished",
+        "Invalid",
+        "Preconditions",
+        "Transitions"
+      ],
+      "type": "string"
     },
     "AutomationStatus": {
       "description": "Generic status type for Automation types.\nIt is used by multiple types.",

--- a/src/schemas/AutomationStepJump.json
+++ b/src/schemas/AutomationStepJump.json
@@ -1,0 +1,33 @@
+{
+  "description": "An external instruction for a process to fast-forward to a step.",
+  "type": "object",
+  "properties": {
+    "processId": {
+      "pattern": "^[0-9a-fA-F\\-]{36}$",
+      "type": "string"
+    },
+    "stepId": {
+      "pattern": "^[0-9a-fA-F\\-]{36}$",
+      "type": "string"
+    },
+    "stepStatus": {
+      "$ref": "#/definitions/AutomationStepActiveStatus"
+    }
+  },
+  "required": [
+    "processId",
+    "stepId"
+  ],
+  "definitions": {
+    "AutomationStepActiveStatus": {
+      "enum": [
+        "Actions",
+        "Created",
+        "Preconditions",
+        "Transitions"
+      ],
+      "type": "string"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/src/shared-types.d.ts
+++ b/src/shared-types.d.ts
@@ -380,6 +380,18 @@ export interface AutomationTemplate extends StoreObject {
   steps: AutomationStep[];
 }
 
+export type AutomationStepActiveStatus =
+  'Created'             // In progress. Not yet evaluated.
+  | 'Preconditions'     // In progress. Checking preconditions.
+  | 'Actions'           // In progress. Applying actions.
+  | 'Transitions'       // In progress. Checking transitions.
+
+export type AutomationStepStatus =
+  AutomationStepActiveStatus
+  | 'Invalid'           // Configuration missing or invalid.
+  | 'Finished'          // End state. Success.
+  | 'Cancelled';        // End state. Execution prematurely ended.
+
 /**
  * A single result from process execution.
  * These are treated as immutable: if the process advances, a new result is added.
@@ -404,13 +416,27 @@ export interface AutomationStepResult {
    * Current status for the relevant step.
    * Will be Invalid if stepId is null.
    */
-  stepStatus: AutomationStatus;
+  stepStatus: AutomationStepStatus;
 
   /**
    * Current status for the entire process.
    * The process will only be evaluated if it is Active.
    */
   processStatus: AutomationStatus;
+
+  /**
+   * Optional error message.
+   */
+  error?: string;
+}
+
+/**
+ * An external instruction for a process to fast-forward to a step.
+ */
+export interface AutomationStepJump {
+  processId: UUID;
+  stepId: UUID;
+  stepStatus?: AutomationStepActiveStatus;
 }
 
 /**

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -2,6 +2,7 @@ import Ajv from 'ajv';
 
 // Run "npm run schemas" to generate these
 import AutomationProcess from './schemas/AutomationProcess.json';
+import AutomationStepJump from './schemas/AutomationStepJump.json';
 import AutomationTask from './schemas/AutomationTask.json';
 import AutomationTemplate from './schemas/AutomationTemplate.json';
 import EventbusMessage from './schemas/EventbusMessage.json';
@@ -20,5 +21,8 @@ export const validateProcess = (data: types.AutomationProcess) =>
 
 export const validateMessage = (data: types.EventbusMessage) =>
   ajv.validate(EventbusMessage, data);
+
+export const validateJump = (data: types.AutomationStepJump) =>
+  ajv.validate(AutomationStepJump, data);
 
 export const lastErrors = () => ajv.errors ?? [];


### PR DESCRIPTION
Adds handling for two process endpoints: /process/init, and /process/jump

Process init takes a template, replaces all UIDs, and checks whether all instances of `transition.next` are valid. It then saves it as a new process.

A process jump is done by applying a new result before the process update call(s). The API schedules the jump, and the processor applies a result based on the jump.

To make the transitions clearer, stepStatus has become a new literal oneof type (`AutomationStepStatus`).
Preconditions, actions, transitions are explicitly named. The name indicates the step is currently on that phase. If a handler concludes the phase, it creates a result where stepStatus is the name of the next phase.

The retrying condition is not present in AutomationStepStatus. Instead, AutomationStepResult now has an optional `error` field. This improves traceability of past errors, while still avoiding spam for persistent errors.

stepStatus is an optional field in AutomationStepJump. By default it is set to `Created`, but overriding this value allows users to manually skip preconditions and/or actions.